### PR TITLE
Allow `@include oGridRespondTo` after declarations.

### DIFF
--- a/config.js
+++ b/config.js
@@ -22,7 +22,8 @@ module.exports = {
          },
          {
             "type": "at-rule",
-            "name": "include"
+            "name": "include",
+            "parameter": "^((?!oGridRespondTo).)*$"
          },
          "declarations"
       ],


### PR DESCRIPTION
The output of `oGridRespondTo` is a media query.