### PR TITLE
Allow newlines in declarations and in and round function arguments.

### DIFF
--- a/config.js
+++ b/config.js
@@ -50,7 +50,7 @@ module.exports = {
       "declaration-bang-space-after": "never",
       "declaration-block-no-duplicate-properties": true,
       "declaration-block-trailing-semicolon": "always",
-      "declaration-colon-space-after": "always",
+      "declaration-colon-space-after": "always-single-line",
       "declaration-colon-space-before": "never",
       "no-duplicate-at-import-rules": true,
       "declaration-no-important": true,
@@ -77,7 +77,7 @@ module.exports = {
       "media-feature-name-no-vendor-prefix": true,
       "at-rule-no-vendor-prefix": true,
       "function-comma-space-after": "always-single-line",
-      "function-parentheses-space-inside": "never",
+      "function-parentheses-space-inside": "never-single-line",
       "indentation": "tab",
       "max-nesting-depth": [3, {
          "ignore": ["blockless-at-rules"]


### PR DESCRIPTION
This is useful for formatting functions with large arguments in a
readable way:
```scss
$some-very-very-very-large-conditional: true;
$foreground-color: if(
	$some-very-very-very-large-conditional == true,
	"then each argument should go on a newline for readability",
	"otherwise each argument could be on the same line"
);
```

And for formatting declarations such as grid areas in a readable
way:
```scss
.foo-grid {
	grid-template-areas:
		"header header header"
		". sidebar ."
		". main ."
		"footer footer footer";
}
```